### PR TITLE
Update .NET SDK version and rollForward policy in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "8.0.300-preview.24203.14"
+    "version": "8.0.204"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "rollForward": "feature",
-    "version": "8.0.100"
+    "rollForward": "latestFeature",
+    "version": "8.0.300-preview.24203.14"
   }
 }


### PR DESCRIPTION
Update .NET SDK version and rollForward policy in global.json

Updated the `rollForward` policy in the `global.json` file from `feature` to `latestFeature` to use the latest available feature band SDK, including minor versions, for the specified major version. Also, the `version` of the SDK specified in the `global.json` file has been updated from `8.0.100` to `8.0.300-preview.24203.14`, meaning the project will now use the `8.0.300-preview.24203.14` version of the .NET SDK.