### PR TITLE
Update .NET SDK to 9.0 and target frameworks

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: dotnet workload restore
       run: dotnet workload restore
     - name: Restore dependencies

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "rollForward": "latestFeature",
-    "version": "8.0.204"
-  }
-}

--- a/sample/Api/Api.csproj
+++ b/sample/Api/Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/sample/AppHost/AppHost.csproj
+++ b/sample/AppHost/AppHost.csproj
@@ -2,7 +2,7 @@
   <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>

--- a/sample/ServiceDefaults/ServiceDefaults.csproj
+++ b/sample/ServiceDefaults/ServiceDefaults.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>
@@ -19,8 +19,8 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
-    <PackageReference Include="Temporalio.Extensions.DiagnosticSource" Version="1.4.0" />
-    <PackageReference Include="Temporalio.Extensions.OpenTelemetry" Version="1.4.0" />
+    <PackageReference Include="Temporalio.Extensions.DiagnosticSource" Version="1.5.0" />
+    <PackageReference Include="Temporalio.Extensions.OpenTelemetry" Version="1.5.0" />
   </ItemGroup>
 
 </Project>

--- a/sample/Worker/Worker.csproj
+++ b/sample/Worker/Worker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Worker-0059691c-eb4b-48c3-980f-e2478ee155e9</UserSecretsId>

--- a/src/InfinityFlow.Aspire.Temporal/InfinityFlow.Aspire.Temporal.csproj
+++ b/src/InfinityFlow.Aspire.Temporal/InfinityFlow.Aspire.Temporal.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageIcon>packageIcon.png</PackageIcon>


### PR DESCRIPTION
- Upgraded .NET SDK version from 8.0.x to 9.0.x in `dotnet.yml`.
- Modified `global.json` to reflect the new SDK version.
- Updated target framework from `net8.0` to `net9.0` in multiple project files.
- Upgraded `Temporalio.Extensions.DiagnosticSource` and `Temporalio.Extensions.OpenTelemetry` packages to version 1.5.0 in `ServiceDefaults.csproj`.