### PR TITLE
Make AddTemporalServerContainer methods synchronous

### DIFF
--- a/sample/AppHost/Program.cs
+++ b/sample/AppHost/Program.cs
@@ -2,14 +2,14 @@ using InfinityFlow.Aspire.Temporal;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-var temporal = await builder.AddTemporalServerContainer("temporal", x => x
+var temporal = builder.AddTemporalServerContainer("temporal", x => x
     .WithLogFormat(LogFormat.Json)
     .WithLogLevel(LogLevel.Info)
     .WithNamespace("test1", "test2")
     .WithDynamicConfigValue("frontend.enableUpdateWorkflowExecution", true)
 );
 
-var temporalWithPorts = await builder.AddTemporalServerContainer("temporalWithPorts", x => x
+var temporalWithPorts = builder.AddTemporalServerContainer("temporalWithPorts", x => x
     .WithPort(12345)
     .WithUiPort(23456)
     .WithLogFormat(LogFormat.Json)

--- a/src/InfinityFlow.Aspire.Temporal/TemporalServerContainerBuilderExtensions.cs
+++ b/src/InfinityFlow.Aspire.Temporal/TemporalServerContainerBuilderExtensions.cs
@@ -12,7 +12,7 @@ public static class TemporalServerContainerBuilderExtensions
     /// <param name="name"></param>
     /// <param name="callback"></param>
     /// <returns></returns>
-    public static Task<IResourceBuilder<TemporalServerContainerResource>> AddTemporalServerContainer(this IDistributedApplicationBuilder builder, string name,
+    public static IResourceBuilder<TemporalServerContainerResource> AddTemporalServerContainer(this IDistributedApplicationBuilder builder, string name,
         Action<TemporalServerResourceBuilder> callback)
     {
         var rb = new TemporalServerResourceBuilder();
@@ -28,11 +28,11 @@ public static class TemporalServerContainerBuilderExtensions
     /// <param name="builder"></param>
     /// <param name="name"></param>
     /// <returns></returns>
-    public static Task<IResourceBuilder<TemporalServerContainerResource>> AddTemporalServerContainer(this IDistributedApplicationBuilder builder, string name)
+    public static IResourceBuilder<TemporalServerContainerResource> AddTemporalServerContainer(this IDistributedApplicationBuilder builder, string name)
     {
         return builder.AddTemporalServerContainer(name, new TemporalServerResourceArguments());
     }
-    private static async Task<IResourceBuilder<TemporalServerContainerResource>> AddTemporalServerContainer(this IDistributedApplicationBuilder builder, string name, TemporalServerResourceArguments args)
+    private static IResourceBuilder<TemporalServerContainerResource> AddTemporalServerContainer(this IDistributedApplicationBuilder builder, string name, TemporalServerResourceArguments args)
     {
         var container = new TemporalServerContainerResource(name, args);
 


### PR DESCRIPTION
Make AddTemporalServerContainer methods synchronous

Removed asynchronous behavior from AddTemporalServerContainer
methods across Program.cs and TemporalServerContainerBuilderExtensions.cs.
Updated method signatures to return IResourceBuilder directly
instead of Task<IResourceBuilder>. Simplified API usage by
eliminating the need for async/await handling when adding
Temporal server containers.

Resolves https://github.com/InfinityFlowApp/aspire-temporal/issues/146