### PR TITLE
Refactor connection string handling in resource classes

### DIFF
--- a/src/InfinityFlow.Aspire.Temporal/TemporalServerExecutableResource.cs
+++ b/src/InfinityFlow.Aspire.Temporal/TemporalServerExecutableResource.cs
@@ -6,38 +6,12 @@ namespace Aspire.Hosting;
 
 public class TemporalServerExecutableResource(string name, TemporalServerResourceArguments arguments) : ExecutableResource(name, command: "temporal", workingDirectory: ""), IResourceWithConnectionString
 {
-    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{GetConnectionString()}");
-
-    public string? GetConnectionString()
-    {
-        var endpoints = this.GetEndpoints().Where(e => e.IsAllocated).ToList();
-        if (endpoints.Count==0)
-        {
-            return null;
-        }
-
-        var server = endpoints.SingleOrDefault(x => x.EndpointName == "server");
-
-        return $"{server?.Host}:{server?.Port}";
-    }
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{this.GetEndpoint("server").Property(EndpointProperty.HostAndPort)}");
 }
 
 public class TemporalServerContainerResource(string name, TemporalServerResourceArguments arguments) : ContainerResource(name,entrypoint: "/temporal"), IResourceWithConnectionString, IResourceWithEnvironment
 {
-    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{GetConnectionString()}");
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{this.GetEndpoint("server").Property(EndpointProperty.HostAndPort)}");
 
     public TemporalServerResourceArguments Arguments { get; } = arguments;
-
-    public string? GetConnectionString()
-    {
-        var endpoints = this.GetEndpoints().Where(e => e.IsAllocated).ToList();
-        if (endpoints.Count == 0)
-        {
-            return null;
-        }
-
-        var server = endpoints.SingleOrDefault(x => x.EndpointName == "server");
-
-        return $"{server?.Host}:{server?.Port}";
-    }
 }


### PR DESCRIPTION
Removed the `GetConnectionString` method from `TemporalServerExecutableResource` and `TemporalServerContainerResource`. Updated the `ConnectionStringExpression` property in both classes to directly use the `GetEndpoint` method with the "server" endpoint and `EndpointProperty.HostAndPort`. This simplifies the code, reduces redundancy, and improves maintainability.